### PR TITLE
Do not move result at end of function

### DIFF
--- a/base/flat_map.h
+++ b/base/flat_map.h
@@ -840,7 +840,7 @@ public:
 		}
 		auto result = std::move(it->second);
 		this->erase(it);
-		return std::move(result);
+		return result;
 	}
 
 private:


### PR DESCRIPTION
This makes GCC 9.1.2 happy with the active -Wredundant-move warning.
Indeed, such moving of local variables or local arguments before
returning is unnecessary and prevents the compiler from copy elision
optimization.

See also: https://github.com/telegramdesktop/tdesktop/pull/6663