### PR TITLE
build_config.h: include ppc64 support

### DIFF
--- a/base/build_config.h
+++ b/base/build_config.h
@@ -46,7 +46,7 @@
 #define ARCH_CPU_X86_FAMILY 1
 #define ARCH_CPU_X86 1
 #define ARCH_CPU_32_BITS 1
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__powerpc64__)
 #define ARCH_CPU_64_BITS 1
 #elif defined(_M_ARM) || defined(__arm__)
 #define ARCH_CPU_32_BITS 1


### PR DESCRIPTION
This change enables Telegram desktop to be build on ppc64(le) Linux.