### PR TITLE
Remove hard #error directives from build_config

### DIFF
--- a/base/build_config.h
+++ b/base/build_config.h
@@ -10,22 +10,6 @@
 
 // thanks Chromium
 
-#if defined(__APPLE__)
-#define OS_MAC 1
-#elif defined(__linux__) // __APPLE__
-#define OS_LINUX 1
-#elif defined(_WIN32) // __APPLE__ || __linux__
-#define OS_WIN 1
-#else // __APPLE__ || __linux__ || _WIN32
-#error Please add support for your platform in base/build_config.h
-#endif // else for __APPLE__ || __linux__ || _WIN32
-
-// For access to standard POSIXish features, use OS_POSIX instead of a
-// more specific macro.
-#if defined(OS_MAC) || defined(OS_LINUX)
-#define OS_POSIX 1
-#endif // OS_MAC || OS_LINUX
-
 // Compiler detection.
 #if defined(__clang__)
 #define COMPILER_CLANG 1
@@ -33,25 +17,21 @@
 #define COMPILER_GCC 1
 #elif defined(_MSC_VER) // __clang__ || __GNUC__
 #define COMPILER_MSVC 1
-#else // _MSC_VER || __clang__ || __GNUC__
-#error Please add support for your compiler in base/build_config.h
-#endif // else for _MSC_VER || __clang__ || __GNUC__
+#endif // _MSC_VER || __clang__ || __GNUC__
 
 // Processor architecture detection.
 #if defined(_M_X64) || defined(__x86_64__)
 #define ARCH_CPU_X86_FAMILY 1
 #define ARCH_CPU_X86_64 1
-#define ARCH_CPU_64_BITS 1
 #elif defined(_M_IX86) || defined(__i386__)
 #define ARCH_CPU_X86_FAMILY 1
 #define ARCH_CPU_X86 1
-#define ARCH_CPU_32_BITS 1
-#elif defined(__aarch64__)
+#endif
+// _LP64 is defined by GCC, others by MSVC
+#if defined _LP64 || defined _M_X64 || defined _M_ARM64 || defined _M_ALPHA
 #define ARCH_CPU_64_BITS 1
-#elif defined(_M_ARM) || defined(__arm__)
-#define ARCH_CPU_32_BITS 1
 #else
-#error Please add support for your architecture in base/build_config.h
+#define ARCH_CPU_32_BITS 1
 #endif
 
 #if defined(__GNUC__)


### PR DESCRIPTION
 * Remove `OS_*` macros that are not used but break build on FreeBSD and GNU/Hurd (see [log][1]).
 * Switch to a more generalized bitness detection with `_LP64` macro.

 [1]: https://buildd.debian.org/status/fetch.php?pkg=telegram-desktop&arch=hurd-i386&ver=1.8.15-2&stamp=1572702800&raw=0