### PR TITLE
Another port to GSL 3.0.0

### DIFF
--- a/base/bytes.h
+++ b/base/bytes.h
@@ -23,7 +23,7 @@ template <gsl::index Size>
 using array = std::array<type, Size>;
 
 inline span make_detached_span(QByteArray &container) {
-	return gsl::as_writeable_bytes(gsl::make_span(container));
+	return gsl::as_writable_bytes(gsl::make_span(container));
 }
 
 template <
@@ -32,7 +32,12 @@ template <
 		!std::is_const_v<Container>
 		&& !std::is_same_v<Container, QByteArray>>>
 inline span make_span(Container &container) {
-	return gsl::as_writeable_bytes(gsl::make_span(container));
+	return gsl::as_writable_bytes(gsl::make_span(container));
+}
+
+template<>
+inline span make_span<span, void>(span &container) {
+	return container;
 }
 
 template <typename Container>
@@ -40,9 +45,13 @@ inline const_span make_span(const Container &container) {
 	return gsl::as_bytes(gsl::make_span(container));
 }
 
+inline const_span make_span(const_span &container) {
+	return container;
+}
+
 template <typename Type, std::ptrdiff_t Extent>
 inline span make_span(gsl::span<Type, Extent> container) {
-	return gsl::as_writeable_bytes(container);
+	return gsl::as_writable_bytes(container);
 }
 
 template <typename Type, std::ptrdiff_t Extent>
@@ -52,7 +61,7 @@ inline const_span make_span(gsl::span<const Type, Extent> container) {
 
 template <typename Type>
 inline span make_span(Type *value, std::size_t count) {
-	return gsl::as_writeable_bytes(gsl::make_span(value, count));
+	return gsl::as_writable_bytes(gsl::make_span(value, count));
 }
 
 template <typename Type>


### PR DESCRIPTION
In addition to renaming gsl::as_writable_bytes in #8, I have added more specific bytes::make_span to eliminate gsl::make_span on gsl::span&lt;gsl::byte&gt;. I have also considered transition gsl::span&lt;gsl::byte&gt;::size_type to unsigned indexes.