### PR TITLE
Fixes for Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ init_target(lib_base_crash_report_writer)
 
 get_filename_component(src_loc . REALPATH)
 
+# Workaround for error: Objective-C 1 was disabled in PCH file but is currently enabled
+if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+    file(GLOB ObjcFiles base/platform/mac/*.mm)
+    set_source_files_properties(${ObjcFiles} PROPERTIES
+        SKIP_PRECOMPILE_HEADERS ON
+        COMPILE_FLAGS "--include base/base_pch.h"
+    )
+endif()
+
 target_precompile_headers(lib_base PRIVATE ${src_loc}/base/base_pch.h)
 nice_target_sources(lib_base ${src_loc}
 PRIVATE

--- a/base/single_instance.cpp
+++ b/base/single_instance.cpp
@@ -34,7 +34,7 @@ const auto QLocalSocket_error = ErrorSignal(&QLocalSocket::error);
 	const auto hash = [](const QString &text) {
 		return crc32(text.data(), text.size() * sizeof(QChar));
 	};
-	const auto ints = std::array{ hash(uniqueApplicationName), hash(path) };
+	const auto ints = std::array<std::int32_t,2>{{ hash(uniqueApplicationName), hash(path) }};
 	auto raw = QByteArray(ints.size() * sizeof(ints[0]), Qt::Uninitialized);
 	memcpy(raw.data(), ints.data(), raw.size());
 	return QString::fromLatin1(raw.toBase64(QByteArray::Base64UrlEncoding));


### PR DESCRIPTION
Workaround for `error: Objective-C 1 was disabled in PCH file but is currently enabled`,
similar to desktop-app/lib_spellcheck#8

This happens because Clang cannot use a PCH emitted while compiling C/C++ for compiling Objective-C sources.

Also fixes `error: no viable constructor or deduction guide for deduction of template arguments of 'array'`