### PR TITLE
Get version on non-Linuxes served by linux code

### DIFF
--- a/base/platform/linux/base_info_linux.cpp
+++ b/base/platform/linux/base_info_linux.cpp
@@ -51,6 +51,9 @@ QString SystemVersionPretty() {
 		struct utsname u;
 		if (uname(&u) == 0) {
 			resultList << u.sysname;
+#ifndef Q_OS_LINUX
+			resultList << u.release;
+#endif // !Q_OS_LINUX
 		} else {
 			resultList << "Unknown";
 		}


### PR DESCRIPTION
Linux is a kernel and its version doesn't matter, but in case of BSDs and etc uname should return actual OS version