### PR TITLE
Provide dummies to fix DESKTOP_APP_DISABLE_DBUS_INTEGRATION=ON build

### DIFF
--- a/base/platform/linux/base_system_media_controls_linux_dummy.cpp
+++ b/base/platform/linux/base_system_media_controls_linux_dummy.cpp
@@ -46,6 +46,12 @@ void SystemMediaControls::setIsStopEnabled(bool value) {
 void SystemMediaControls::setPlaybackStatus(PlaybackStatus status) {
 }
 
+void SystemMediaControls::setLoopStatus(LoopStatus status) {
+}
+
+void SystemMediaControls::setShuffle(bool value) {
+}
+
 void SystemMediaControls::setTitle(const QString &title) {
 }
 


### PR DESCRIPTION
tdesktop 3.3.2 beta no longer builds whith dbus disabled due to missing
`setLoopStatus` and `setShuffle` symbols;  provide the missing dummies.
