### PR TITLE
Avoid conflict between GLib and Qt basic types

### DIFF
--- a/base/platform/linux/base_linux_glibmm_helper.h
+++ b/base/platform/linux/base_linux_glibmm_helper.h
@@ -10,6 +10,7 @@
 
 #include <glibmm/variant.h>
 
+#ifdef _LP64
 namespace Glib {
 
 template <>
@@ -103,6 +104,7 @@ public:
 };
 
 } // namespace Glib
+#endif // 64bit
 
 namespace base {
 namespace Platform {


### PR DESCRIPTION
Typedefs gint64 and qint64 as well as guint64 and quint64 coincide on 32-bit platforms and compiler encounters redefinitions of `class Glib::Variant<long long int>` and `class Glib::Variant<long long unsigned int>`.