### PR TITLE
Fix errors related to std::vector

### DIFF
--- a/base/platform/base_platform_info.h
+++ b/base/platform/base_platform_info.h
@@ -4,6 +4,7 @@
 // For license and copyright information please follow this link:
 // https://github.com/desktop-app/legal/blob/master/LEGAL
 //
+#include <vector>
 #pragma once
 
 class QJsonObject;


### PR DESCRIPTION
This fixes errors C2039 and C2061 that occur in line 21 of base_platform_info,h when trying to build this repo.
Also fixes https://github.com/desktop-app/lib_base/issues/150