### PR TITLE
Use jpeg quality level 90 at least

### DIFF
--- a/base/platform/linux/base_system_media_controls_linux.cpp
+++ b/base/platform/linux/base_system_media_controls_linux.cpp
@@ -629,7 +629,7 @@ void SystemMediaControls::setArtist(const QString &artist) {
 void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
 	QByteArray thumbnailData;
 	QBuffer thumbnailBuffer(&thumbnailData);
-	thumbnail.save(&thumbnailBuffer, "JPG", 87);
+	thumbnail.save(&thumbnailBuffer, "JPG", 90);
 
 	_private->player().metadata["mpris:artUrl"] =
 		Q2VUString("data:image/jpeg;base64," + thumbnailData.toBase64());

--- a/base/platform/win/base_system_media_controls_win.cpp
+++ b/base/platform/win/base_system_media_controls_win.cpp
@@ -238,7 +238,7 @@ void SystemMediaControls::setThumbnail(const QImage &thumbnail) {
 		QByteArray bytes;
 		QBuffer buffer(&bytes);
 		buffer.open(QIODevice::WriteOnly);
-		thumbnail.save(&buffer, "JPG", 87);
+		thumbnail.save(&buffer, "JPG", 90);
 		buffer.close();
 		return std::vector<unsigned char>(bytes.begin(), bytes.end());
 	}();


### PR DESCRIPTION
To ensure mozjpeg's chroma subsampling 4:4:4 is used