### PR TITLE
Repeat Qt's fix for stale timestamp

### DIFF
--- a/base/platform/linux/base_linux_xcb_utilities.cpp
+++ b/base/platform/linux/base_linux_xcb_utilities.cpp
@@ -34,7 +34,7 @@ public:
 			return std::nullopt;
 		}
 
-		const auto atom = GetAtom(_connection, "CLIP_TEMPORARY");
+		const auto atom = GetAtom(_connection, "_DESKTOP_APP_GET_TIMESTAMP");
 		if (!atom.has_value()) {
 			return std::nullopt;
 		}
@@ -46,7 +46,7 @@ public:
 
 		xcb_change_property(
 			_connection,
-			XCB_PROP_MODE_APPEND,
+			XCB_PROP_MODE_REPLACE,
 			_window,
 			_atom,
 			XCB_ATOM_INTEGER,
@@ -57,7 +57,6 @@ public:
 		xcb_flush(_connection);
 		sync();
 		_loop.exec();
-		xcb_delete_property(_connection, _window, _atom);
 
 		return _timestamp;
 	}


### PR DESCRIPTION
The TimestampGetter is made based on the code from QXcbConnection::getTimestamp which used CLIP_TEMPORARY property that has to be deleted. As delete events provide the timestamp of when the property was added, the gotten timestamp is in fact way older than it should be. Qt has switched to a custom property to avoid this, do the same.