### PR TITLE
Use modern openssl functions

### DIFF
--- a/base/openssl_help.h
+++ b/base/openssl_help.h
@@ -463,7 +463,7 @@ void ShaImpl(bytes::span dst, auto md, auto &&...args) {
 	};
 	(update(args), ...);
 
-	EVP_DigestFinal(mdctx, reinterpret_cast<unsigned char*>(dst.data()), nullptr);
+	EVP_DigestFinal_ex(mdctx, reinterpret_cast<unsigned char*>(dst.data()), nullptr);
 	EVP_MD_CTX_free(mdctx);
 }
 

--- a/base/openssl_help.h
+++ b/base/openssl_help.h
@@ -470,19 +470,15 @@ void ShaImpl(bytes::span dst, auto md, Args &&...args) {
 	EVP_MD_CTX_free(mdctx);
 }
 
-inline void ShaTo(bytes::span dst, auto mdname, bytes::const_span data) {
-	auto md = EVP_MD_fetch(nullptr, mdname, nullptr);
+inline void ShaTo(bytes::span dst, auto md, bytes::const_span data) {
 	Expects(dst.size() >= EVP_MD_size(md));
 	details::ShaImpl(dst, md, data);
-	EVP_MD_free(md);
 }
 
 template <typename ...Args>
-[[nodiscard]] inline bytes::vector Sha(auto mdname, Args &&...args) {
-	auto md = EVP_MD_fetch(nullptr, mdname, nullptr);
+[[nodiscard]] inline bytes::vector Sha(auto md, Args &&...args) {
 	bytes::vector dst(EVP_MD_size(md));
 	details::ShaImpl(dst, md, args...);
-	EVP_MD_free(md);
 	return dst;
 }
 
@@ -514,30 +510,30 @@ constexpr auto kSha256Size = size_type(SHA256_DIGEST_LENGTH);
 constexpr auto kSha512Size = size_type(SHA512_DIGEST_LENGTH);
 
 inline void Sha1To(bytes::span dst, bytes::const_span data) {
-	details::ShaTo(dst, "SHA1", data);
+	details::ShaTo(dst, EVP_sha1(), data);
 }
 
 template <typename ...Args>
 [[nodiscard]] inline bytes::vector Sha1(Args &&...args) {
-	return details::Sha("SHA1", args...);
+	return details::Sha(EVP_sha1(), args...);
 }
 
 inline void Sha256To(bytes::span dst, bytes::const_span data) {
-	details::ShaTo(dst, "SHA256", data);
+	details::ShaTo(dst, EVP_sha256(), data);
 }
 
 template <typename ...Args>
 [[nodiscard]] inline bytes::vector Sha256(Args &&...args) {
-	return details::Sha("SHA256", args...);
+	return details::Sha(EVP_sha256(), args...);
 }
 
 inline void Sha512To(bytes::span dst, bytes::const_span data) {
-	details::ShaTo(dst, "SHA512", data);
+	details::ShaTo(dst, EVP_sha512(), data);
 }
 
 template <typename ...Args>
 [[nodiscard]] inline bytes::vector Sha512(Args &&...args) {
-	return details::Sha("SHA512", args...);
+	return details::Sha(EVP_sha512(), args...);
 }
 
 inline bytes::vector Pbkdf2Sha512(

--- a/base/openssl_help.h
+++ b/base/openssl_help.h
@@ -447,7 +447,10 @@ private:
 
 namespace details {
 
-void ShaImpl(bytes::span dst, auto md, auto &&...args) {
+template <
+	typename ...Args,
+	typename = std::enable_if_t<(sizeof...(Args) >= 1)>>
+void ShaImpl(bytes::span dst, auto md, Args &&...args) {
 	Expects(dst.size() >= EVP_MD_size(md));
 
 	EVP_MD_CTX *mdctx = EVP_MD_CTX_create();

--- a/base/openssl_help.h
+++ b/base/openssl_help.h
@@ -272,12 +272,7 @@ public:
 		if (failed() || !_data) {
 			return false;
 		}
-		constexpr auto kMillerRabinIterationCount = 64;
-		const auto result = BN_is_prime_ex(
-			raw(),
-			kMillerRabinIterationCount,
-			context.raw(),
-			nullptr);
+		const auto result = BN_check_prime(raw(), context.raw(), nullptr);
 		if (result == 1) {
 			return true;
 		} else if (result != 0) {


### PR DESCRIPTION
Hello. I replaced some functions which are declared as deprecated in OpenSSL 3.0 (cause it's a minimum supported version nowadays) as per its [migration guide](https://docs.openssl.org/3.0/man7/migration_guide/). This allows to fix some build warnings (I noticed quite a lot of such warnings in telegram codebase BTW).

Also, happy new year!