### PR TITLE
Fix missing Gio::DesktopAppInfo when building against GLib 2.86

### DIFF
--- a/base/platform/linux/base_url_scheme_linux.cpp
+++ b/base/platform/linux/base_url_scheme_linux.cpp
@@ -16,6 +16,11 @@
 
 #include <gio/gio.hpp>
 #include <snapcraft/snapcraft.hpp>
+#if __has_include(<giounix/giounix.hpp>)
+#include <giounix/giounix.hpp>
+#else // __has_include(<giounix/giounix.hpp>)
+#define GioUnix Gio
+#endif // !__has_include(<giounix/giounix.hpp>)
 
 namespace base::Platform {
 namespace {
@@ -117,7 +122,7 @@ void RegisterUrlScheme(const UrlSchemeDescriptor &descriptor) {
 
 	const auto appId = QGuiApplication::desktopFileName().toStdString();
 	if (!appId.empty()) {
-		Gio::AppInfo appInfo = Gio::DesktopAppInfo::new_(appId + ".desktop");
+		Gio::AppInfo appInfo = GioUnix::DesktopAppInfo::new_(appId + ".desktop");
 		if (appInfo) {
 			if (appInfo.get_commandline() == commandlineForCreator + " %u") {
 				appInfo.set_as_default_for_type(handlerType);


### PR DESCRIPTION
GLib introduced a separate GIR file, GioUnix-2.0, for platform-specific GIO APIs[1] in GLib 2.79.2[2], while still exposing them in Gio-2.0 for backward compatibility by creating duplicated types.

However, GNOME developers have found the duplicated types could confuse gobject-introspection[3]. As a solution, these types are removed[4] from Gio-2.0 since GLib 2.86.0[5].

Since we make use of DesktopAppInfo in base_url_scheme_linux.cpp, lib_base is affected by the breakage. This patch introduces a conditional compilation block to prefer GioUnix::DesktopAppInfo over the one in Gio namespace when GLib is newer than 2.86.0, in which case binding for DesktopAppInfo will be generated from GioUnix-2.0 instead of Gio-2.0.

Link: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3892 # [1]
Link: https://gitlab.gnome.org/GNOME/glib/-/commit/342fa9c1610d#9f621eb5fd3bcb2fa5c7bd228c9b1ad42edc46c8_1_17 # [2]
Link: https://gitlab.gnome.org/GNOME/glib/-/issues/3744 # [3]
Link: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4761 # [4]
Link: https://gitlab.gnome.org/GNOME/glib/-/commit/e33be08bda99#9f621eb5fd3bcb2fa5c7bd228c9b1ad42edc46c8_1_4 # [5]