### PR TITLE
Show now playing metadata on macOS even without a known duration

### DIFF
--- a/base/platform/mac/base_system_media_controls_mac.mm
+++ b/base/platform/mac/base_system_media_controls_mac.mm
@@ -384,9 +384,7 @@ void SystemMediaControls::clearMetadata() {
 void SystemMediaControls::updateDisplay() {
 	[[MPNowPlayingInfoCenter defaultCenter]
 		performSelectorOnMainThread:@selector(setNowPlayingInfo:)
-		withObject:((_private->enabled && _private->duration())
-			? _private->info
-			: nil)
+		withObject:(_private->enabled ? _private->info : nil)
 		waitUntilDone:false];
 }
 


### PR DESCRIPTION
On macOS the Control Center, lock screen and media-keys HUD showed that Telegram was playing audio but without any track title, artist or artwork.

`updateDisplay()` published the `MPNowPlayingInfoCenter` dictionary only when both `enabled` and `duration()` were set, while `setPlaybackStatus()` assigns the global `MPNowPlayingInfoCenter.playbackState` unconditionally — so the app was registered as the active player even though its info dictionary was `nil`. The duration is not always available (audio without a duration attribute, or the short window before the media header is parsed, with no later re-publish), which produced the "playing, but no info" state.

Gate `updateDisplay()` on `enabled` only — that flag already tracks whether there is active media and is cleared together with `clearMetadata()` on stop. This also matches the Windows and Linux backends, which never gate the metadata on the duration.